### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -126,6 +126,8 @@ jobs:
     needs: [build, provenance]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write # Required to create a release and upload assets.
     steps: 
       - name: Create release
         uses: softprops/action-gh-release@v2.2.2


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/traffic-operator/security/code-scanning/5](https://github.com/PKopel/traffic-operator/security/code-scanning/5)

To fix the issue, we need to add a `permissions` block to the `release` job. This block should grant only the permissions required for the job to function. Based on the usage of `softprops/action-gh-release@v2.2.2`, the job likely requires `contents: write` to create a release and upload assets. All other permissions should be omitted or set to `read` to minimize access.

The `permissions` block will be added under the `release` job definition, ensuring that it does not inherit unnecessary permissions from the repository or workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
