### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,6 +28,8 @@ jobs:
   build:
     needs: [test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       bundle-image: ${{ steps.bundle.outputs.image }}
       bundle-digest: ${{ steps.bundle.outputs.digest }}


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/traffic-operator/security/code-scanning/4](https://github.com/PKopel/traffic-operator/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the `build` job. Since the `build` job primarily interacts with the repository contents and does not require write access, we will set `contents: read` as the minimal permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
