### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 env:
   VERSION: "0.0.0"
 


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/traffic-operator/security/code-scanning/3](https://github.com/PKopel/traffic-operator/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required for the workflow. Based on the provided workflow, the following permissions are appropriate:

- `contents: read`: Required for basic CI operations like checking out the repository.
- Additional permissions will be added only where necessary, such as in the `provenance` job, which already defines its specific permissions.

This change ensures that the workflow adheres to the principle of least privilege while maintaining its functionality.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
