### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: Run on Ubuntu


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/traffic-operator/security/code-scanning/2](https://github.com/PKopel/traffic-operator/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves cloning the repository, setting up Go, installing tools, and running tests, it only requires `contents: read` permissions. This ensures that the workflow has the minimal permissions necessary to function correctly while reducing the risk of unintended actions.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
