### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Run on Ubuntu


### PR DESCRIPTION
Potential fix for [https://github.com/PKopel/traffic-operator/security/code-scanning/1](https://github.com/PKopel/traffic-operator/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only clones the repository and runs a linter, it likely only needs `contents: read` permissions. This change will ensure that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
